### PR TITLE
Fix Documenter deployment target

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ pages = [
 )
 
 deploydocs(
-    repo = "github.com/QuantumSavory/Quantikz.git",
+    repo = "github.com/QuantumSavory/Quantikz.jl.git",
     devbranch = "main",
+    push_preview = true,
 )


### PR DESCRIPTION
## Summary

- correct the Documenter repository target to QuantumSavory/Quantikz.jl
- enable pull-request preview deployment

## Validation

- parsed docs/make.jl with Julia
- verified the staged diff with git diff --check