### PR TITLE
Raise incompatible dependency floors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,8 +13,8 @@ tectonic_jll = "d7dd28d6-a5e6-559c-9131-7eb760cdacc5"
 
 [compat]
 FileIO = "1.17"
-Ghostscript_jll = "9.53"
-ImageMagick = "1.4"
+Ghostscript_jll = "9.55.1"
+ImageMagick = "1.4.2"
 ImageMagick_jll = "7.1.2002"
 julia = "1.11"
 tectonic_jll = "0.15, 0.16"


### PR DESCRIPTION
## Summary

- raise the ImageMagick lower bound from 1.4.0 to 1.4.2
- raise the Ghostscript_jll lower bound from 9.53.0 to 9.55.1
- make the declared direct-dependency floors jointly resolvable in downgrade CI

The previous floors caused the forced-dependency check in Actions run 31326117662 to resolve newer versions and fail its lower-bound assertions.

## Validation

- julia-downgrade-compat v2.7.0, projects=.,test, mode=forcedeps: passed all lower-bound checks on Julia 1.12.6
- Pkg.instantiate, Pkg.build, Pkg.precompile, and Pkg.test with allow_reresolve=false against the generated minimum-version manifests: passed